### PR TITLE
Default table sorting by stars desc #29

### DIFF
--- a/frontend/src/app/data-table.tsx
+++ b/frontend/src/app/data-table.tsx
@@ -30,7 +30,12 @@ export function DataTable<TData, TValue>({
   columns,
   data,
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    {
+      id: "stars",
+      desc: true,
+    },
+  ]);
   const table = useReactTable({
     data,
     columns,


### PR DESCRIPTION
Initialize the table's sorting state to sort by the "stars" column in descending order by default. This ensures the data table shows highest-starred items first on initial render by setting useState<SortingState>([{ id: "stars", desc: true }]).