### PR TITLE
feat(frontend): default repository sort to stars (desc)

### DIFF
--- a/frontend/src/app/data-table.tsx
+++ b/frontend/src/app/data-table.tsx
@@ -24,13 +24,15 @@ import { useState } from "react";
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  initialSorting?: SortingState;
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
+  initialSorting = [],
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>(initialSorting);
   const table = useReactTable({
     data,
     columns,

--- a/frontend/src/app/repos-table.tsx
+++ b/frontend/src/app/repos-table.tsx
@@ -76,7 +76,11 @@ export function ReposTable({
       <div className="container mb-4 max-w-xl" ref={_ref}>
         <SearchForm onSubmit={onSearchSubmit} dependencies={dependencies} />
       </div>
-      <DataTable columns={columns} data={searchedRepos} />
+      <DataTable
+        columns={columns}
+        data={searchedRepos}
+        initialSorting={[{ id: "stars", desc: true }]}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Closes #29.
- Set the repositories table default sort key to `stars`.
- Set the default sort direction to descending (`desc`) so highest-starred repos appear first.
- Kept existing sort UI behavior, so users can still toggle sorting from the Stars column header.

## Changes
- Updated `DataTable` to accept an optional `initialSorting` prop.
- Passed `initialSorting={[{ id: "stars", desc: true }]}` from `ReposTable`.

## Verification
- Ran the app locally at `http://localhost:3000`.
- Confirmed the first rows are ordered by Stars descending on initial load.
- Confirmed clicking the Stars header still toggles sort order.